### PR TITLE
Moved camera system to a rudimentary ECS setup

### DIFF
--- a/kazaam2d.csproj
+++ b/kazaam2d.csproj
@@ -110,9 +110,11 @@
     <Compile Include="src\Systems\WorldSystem.cs" />
     <Compile Include="src\Systems\RenderSystem.cs" />
     <Compile Include="src\Systems\DynamicsSystem.cs" />
+    <Compile Include="src\Systems\CameraSystem.cs" />
     <Compile Include="src\Components\PhysicsComponent.cs" />
     <Compile Include="src\Components\RenderComponent.cs" />
     <Compile Include="src\Components\PlayerComponent.cs" />
+    <Compile Include="src\Components\CameraComponent.cs" />
     <Compile Include="src\Objects\Body.cs" />
     <Compile Include="src\GameObjectFactory.cs" />
     <Compile Include="src\Systems\PlayerSystem.cs" />

--- a/src/Camera.cs
+++ b/src/Camera.cs
@@ -23,10 +23,6 @@ namespace Kazaam.View
     protected XNAGame game;
     protected OrthographicCamera InternalCamera;
 
-    // Platformer Camera limits
-    protected float HorizontalFocusLimit;
-    protected float VerticalFocusLimit;
-
     public Camera(XNAGame game) {
       this.game = game;
       var viewportAdapter = new BoxingViewportAdapter(game.Window, game.GraphicsDevice, (int)game.Resolution.X, (int)game.Resolution.Y);

--- a/src/Components/CameraComponent.cs
+++ b/src/Components/CameraComponent.cs
@@ -1,0 +1,11 @@
+using Kazaam.Objects;
+
+using MonoGame.Extended;
+
+namespace Kazaam.View {
+  public class CameraComponent {
+    public Body CameraFocus {get; set;}
+    public float Zoom {get; set;}
+    public OrthographicCamera InternalCamera {get; set;} 
+  }
+}

--- a/src/Map.cs
+++ b/src/Map.cs
@@ -42,8 +42,8 @@ namespace Kazaam.Universe
         sb.Begin(samplerState: SamplerState.PointClamp);
         //sb.Draw(background, new Rectangle(0, 0, (int)scene.game.Resolution.X, (int)scene.game.Resolution.Y), Color.White);
         sb.End();
-        sb.Begin(transformMatrix: scene.mainCamera.GetViewMatrix(), samplerState: SamplerState.PointClamp);
-        mapRenderer.Draw(scene.mainCamera.GetViewMatrix());
+        sb.Begin(transformMatrix: scene.CameraMatrix, samplerState: SamplerState.PointClamp);
+        mapRenderer.Draw(scene.CameraMatrix);
         sb.End();
       }
     } 

--- a/src/Scene.cs
+++ b/src/Scene.cs
@@ -27,13 +27,16 @@ namespace Kazaam {
 		public HumperWorld hworld;
     public SceneWorld sworld;
     public Map _map;
-    public Camera mainCamera;
     public GameObjectFactory Factory { get; set; } 
 		public ArrayList _objects = new ArrayList();
 
 		public float Gravity { get; }
     public Vector2 Vec { get; set; }
 
+    // Camera
+    public int CameraId {get; set;}
+    public Matrix CameraMatrix {get; set;}
+    public Body CameraFocus {get; set;}
 
 		public Scene(XNAGame game, SceneWorld world) {
 			this.game = game;
@@ -41,19 +44,8 @@ namespace Kazaam {
       
       hworld = new HumperWorld(120 * 32, 120 * 32);
 
-      // World physics
-			Gravity = 9.8f;
-
       // Camera
-      mainCamera = new Camera(game);
-		}
-
-    public void SetCameraFocus(Body focus) {
-      mainCamera.CameraFocus = focus;
-    }
-
-		public ArrayList SceneObjects() {
-			return _objects;
+      SetupCamera();
 		}
 
     /// <summary>
@@ -78,6 +70,22 @@ namespace Kazaam {
       return;
     }
 
+    private void SetupCamera() {
+      var cameraEntity = sworld.CreateEntity();
+      var viewportAdapter = new BoxingViewportAdapter(game.Window, game.GraphicsDevice, (int)game.Resolution.X, (int)game.Resolution.Y);
+      var cameraComponent = new CameraComponent();
+      cameraComponent.InternalCamera = new OrthographicCamera(viewportAdapter);
+      cameraComponent.CameraFocus = CameraFocus;
+      cameraEntity.Attach(new Body());
+      cameraEntity.Attach(cameraComponent);
+      CameraId = cameraEntity.Id;
+    }
+
+    public void SetCameraFocus(Body body) {
+      var cameraEntity = sworld.GetEntity(CameraId);
+      var cameraComponent = cameraEntity.Get<CameraComponent>();
+      cameraComponent.CameraFocus = body;
+    }
 
   }
 }

--- a/src/Systems/CameraSystem.cs
+++ b/src/Systems/CameraSystem.cs
@@ -1,0 +1,43 @@
+using Kazaam.Objects;
+
+using Microsoft.Xna.Framework;
+
+using MonoGame.Extended.Entities;
+using MonoGame.Extended.Entities.Systems;
+using MonoGame.Extended.ViewportAdapters;
+
+namespace Kazaam.View {
+  public class CameraSystem : EntityProcessingSystem {
+    private ComponentMapper<Body> _bodyMapper;
+    private ComponentMapper<CameraComponent> _cameraMapper;
+    private readonly XNAGame game;
+    private int xres;
+    private int yres;
+
+    public CameraSystem(XNAGame game) : base(Aspect.All(typeof(CameraComponent), typeof(Body))) {
+      this.game = game;
+      xres = (int)game.Resolution.X;
+      yres = (int)game.Resolution.Y;
+    }
+
+    public override void Initialize(IComponentMapperService mapperService) {
+      _cameraMapper = mapperService.GetMapper<CameraComponent>();
+      _bodyMapper = mapperService.GetMapper<Body>();
+    }
+
+    public override void Process(GameTime gameTime, int entityId) {
+      var body = _bodyMapper.Get(entityId);
+      var camera = _cameraMapper.Get(entityId);
+
+      // Update the camera's position to the current focus
+      var viewportAdapter = new BoxingViewportAdapter(game.Window, game.GraphicsDevice, xres, yres);
+      var center = new Vector2(viewportAdapter.VirtualWidth/2f, viewportAdapter.VirtualHeight/2f);
+      var centerOfObject = new Vector2(camera.CameraFocus.Position.X + (camera.CameraFocus.Bounds.Width / 2), camera.CameraFocus.Position.Y + (camera.CameraFocus.Bounds.Height / 2));
+      body.Position = centerOfObject;
+      camera.InternalCamera.Position = body.Position -= center;
+
+      // Update the scene's current transform matrix
+      game.scene.CameraMatrix = camera.InternalCamera.GetViewMatrix();
+    }
+  }
+}

--- a/src/Systems/RenderSystem.cs
+++ b/src/Systems/RenderSystem.cs
@@ -48,12 +48,13 @@ namespace Kazaam.View {
         }
 
         Rectangle sourceRectangle = body.CurrentAnimation.CurrentRectangle;
-        var transformMatrix = _game.scene.mainCamera.GetViewMatrix();
+        var transformMatrix = _game.scene.CameraMatrix;
         _game.GameWindow.spriteBatch.Begin(transformMatrix : transformMatrix, samplerState: SamplerState.PointClamp);
 
         foreach (Hitbox hb in body.hitboxes) {
           hb.Draw(_game.GameWindow.spriteBatch, _game.scene);
         }
+
 			  _game.GameWindow.spriteBatch.Draw(
              renderComp.Texture,
              new Vector2(body.Bounds.X * body.Scale, body.Bounds.Y * body.Scale),

--- a/src/XNAGame.cs
+++ b/src/XNAGame.cs
@@ -21,7 +21,7 @@ namespace Kazaam {
     /// The main game engine class that handles the game loop, physics updates and rendering.
     /// </summary>
     public class XNAGame : Game {
-      private World _world;
+      protected World _world;
       public Stack states;
       public Vector2 Resolution;
       public Scene scene;
@@ -46,12 +46,13 @@ namespace Kazaam {
           .AddSystem(new PlayerSystem())
           .AddSystem(new RenderSystem(this))
           .AddSystem(new DynamicsSystem())
+          .AddSystem(new CameraSystem(this))
           .Build();
 
         Components.Add(_world);
         states = new Stack();
         scene = new Scene(this, _world);
-				InputManager.Initialize();
+        InputManager.Initialize();
         IsFixedTimeStep = false;
 
         // Json Asset loader
@@ -79,9 +80,8 @@ namespace Kazaam {
       }
 
       protected override void Update(GameTime gameTime) {
-        this.scene.mainCamera.Update(gameTime);
-	    InputManager.Update(); // Input manager is ALWAYS called
         _world.Update(gameTime);
+        InputManager.Update(); // Input manager is ALWAYS called
         base.Update(gameTime);
       }
     }


### PR DESCRIPTION
Fixes #14 

This sets up the infastructure for cameras to exist in the ECS system. I don't like the "main camera" setup but the way this is currently working, multiple cameras could theoretically exist.

Why do this?
- Multiple cameras (minimap, "remote cameras", cutscene cameras)
- By moving the cameras to the ECS we could have cool things happen such as cameras that are effected by physics.