### PR TITLE
Added sprite class and loader to abstract away from Texture2D

### DIFF
--- a/kazaam2d.csproj
+++ b/kazaam2d.csproj
@@ -101,6 +101,7 @@
     <Compile Include="src\Loaders\MapLoader.cs" />
     <Compile Include="src\Loaders\SongLoader.cs" />
     <Compile Include="src\Loaders\SoundLoader.cs" />
+    <Compile Include="src\Loaders\SpriteLoader.cs" />
     <Compile Include="src\Map.cs" />
     <Compile Include="src\Music.cs" />
     <Compile Include="src\Namespaces.cs" />
@@ -108,6 +109,7 @@
     <Compile Include="src\Objects\Body.cs" />
     <Compile Include="src\Scene.cs" />
     <Compile Include="src\SoundManager.cs" />
+    <Compile Include="src\Sprite.cs" />
     <Compile Include="src\State.cs" />
     <Compile Include="src\Systems\CameraSystem.cs" />
     <Compile Include="src\Systems\DynamicsSystem.cs" />

--- a/src/Components/RenderComponent.cs
+++ b/src/Components/RenderComponent.cs
@@ -1,3 +1,4 @@
+using Kazaam.Assets;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Kazaam.Objects {
@@ -6,9 +7,9 @@ namespace Kazaam.Objects {
     public SpriteEffects Effects {get; set;}
     public int Scale {get; set;}
 
-    public RenderComponent(Texture2D texture, SpriteEffects effects = SpriteEffects.None, int scale = 1) {
-      Texture = texture;
-      Effects = effects;
+    public RenderComponent(Sprite sprite, bool flip = false, int scale = 1) {
+      Texture = sprite.Texture;
+      Effects = flip ? SpriteEffects.FlipHorizontally : SpriteEffects.None;
       Scale = scale;
     }
   }

--- a/src/Loaders/SpriteLoader.cs
+++ b/src/Loaders/SpriteLoader.cs
@@ -1,0 +1,11 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Kazaam.Assets {
+  public class SpriteLoader : IContentLoader {
+    public object Load(XNAGame game, string contentPath) {
+      Texture2D texture = game.Content.Load<Texture2D>(contentPath);
+      var sprite = new Sprite(texture);
+      return sprite;
+    }
+  }
+}

--- a/src/Sprite.cs
+++ b/src/Sprite.cs
@@ -1,0 +1,11 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Kazaam.Assets {
+  public class Sprite {
+    public readonly Texture2D Texture;
+
+    public Sprite(Texture2D texture) {
+      Texture = texture;
+    }
+  }
+}

--- a/src/XNAGame.cs
+++ b/src/XNAGame.cs
@@ -64,6 +64,7 @@ namespace Kazaam {
         contentLoader.RegisterType("maps", new MapLoader());
         contentLoader.RegisterType("sounds", new SoundLoader());
         contentLoader.RegisterType("songs", new SongLoader());
+        contentLoader.RegisterType("sprites", new SpriteLoader());
       }
 
       protected void SetResolution(int x, int y) {


### PR DESCRIPTION
Implements #18 

We don't really want to make reference to Texture2D, which is an internal XNA class. Abstract it away using sprite. The sprite class will likely grow.