### PR TITLE
Moved HumperWorld to map

### DIFF
--- a/src/Loaders/MapLoader.cs
+++ b/src/Loaders/MapLoader.cs
@@ -53,7 +53,7 @@ namespace Kazaam.Assets
                     var body = new Body();
                     body.Dimensions = new Vector2(map.tileWidth, map.tileHeight);
                     body.Position = new Vector2(map.tileWidth * x, map.tileHeight * y);
-                    body.Bounds = game.scene.HumperWorld.Create(body.Position.X, body.Position.Y, body.Dimensions.X, body.Dimensions.Y);
+                    body.Bounds = map.HumperWorld.Create(body.Position.X, body.Position.Y, body.Dimensions.X, body.Dimensions.Y);
                     body.Bounds.AddTags(Enums.Tags.Platforms);
                     var entity = game.scene.SceneWorld.CreateEntity();
                     entity.Attach(body);

--- a/src/Map.cs
+++ b/src/Map.cs
@@ -1,5 +1,5 @@
-﻿using Kazaam.Objects;
-
+﻿using HumperWorld = Humper.World;
+using Kazaam.Objects;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.Tiled;
@@ -16,6 +16,8 @@ namespace Kazaam.Universe
 
       private TiledMapRenderer mapRenderer;
 
+      public int width;
+      public int height;
       public int tileWidth;
       public int tileHeight;
 
@@ -25,11 +27,16 @@ namespace Kazaam.Universe
 
       public Vector2 StartingPosition;
 
+      public HumperWorld HumperWorld {get; set;}
+
       public Map(TiledMap map, int tileWidth, int tileHeight, GraphicsDevice gd) {
         this.map = map;
         this.mapRenderer = new TiledMapRenderer(gd, map);
+        width = map.Width;
+        height = map.Height;
         this.tileWidth = tileWidth;
         this.tileHeight = tileHeight;
+        HumperWorld = new HumperWorld(tileWidth * width, tileHeight * height);
         //background = this.scene.game.Content.Load<Texture2D>("resources/bin/maps/surface/bg1");
       }
 

--- a/src/Scene.cs
+++ b/src/Scene.cs
@@ -5,8 +5,6 @@ using Kazaam.View;
 using Microsoft.Xna.Framework.Media;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.Entities;
-using MonoGame.Extended.ViewportAdapters;
-using MonoGame.Extended;
 using SceneWorld = MonoGame.Extended.Entities.World;
 
 namespace Kazaam {
@@ -15,12 +13,10 @@ namespace Kazaam {
   /// A collection of Kazaam.Universe objects that define a world in the engine.
   /// </summary>
   public class Scene { 
+    public Map Map {get; set;}
     public readonly XNAGame Game;
 
-    // Scene structures
-    public HumperWorld HumperWorld {get; set;}
     public SceneWorld SceneWorld {get; set;}
-    public Map Map {get; set;}
 
     // Camera
     public int CameraId {get; set;}
@@ -29,8 +25,6 @@ namespace Kazaam {
 
     public Scene(XNAGame game) {
       this.Game = game;
-      
-      HumperWorld = new HumperWorld(120 * 32, 120 * 32);
     }
 
     /// <summary>


### PR DESCRIPTION
The HumperWorld (which contains collision information for every game object) has been moved from the scene to the Map.

Fixes #17 