### PR TITLE
Capped engine at 60 FPS

### DIFF
--- a/src/XNAGame.cs
+++ b/src/XNAGame.cs
@@ -35,7 +35,7 @@ namespace Kazaam {
       }
 
       public virtual void InitializeEngine() {
-        IsFixedTimeStep = false;
+        IsFixedTimeStep = true; // Caps the engine at 60 FPS.
         states = new Stack();
         scene = new Scene(this);
       }


### PR DESCRIPTION
Fixes #32 

Uncapped FPS screws up delta calculations which is used to smooth out movement and animation. Limit the engine to 60 FPS by default. Because of the template design pattern, a user can change this limit if they want to.