### PR TITLE
Strategy pattern used to load map objects

### DIFF
--- a/kazaam2d.csproj
+++ b/kazaam2d.csproj
@@ -99,6 +99,7 @@
     <Compile Include="src\IGameState.cs" />
     <Compile Include="src\IPlayer.cs" />
     <Compile Include="src\ISound.cs" />
+    <Compile Include="src\ITiledStrategy.cs" />
     <Compile Include="src\InputManager.cs" />
     <Compile Include="src\JsonFileStream.cs" />
     <Compile Include="src\Loaders\AnimationLoader.cs" />

--- a/src/ITiledStrategy.cs
+++ b/src/ITiledStrategy.cs
@@ -1,0 +1,10 @@
+using Kazaam.Universe;
+
+namespace Kazaam.Assets {
+  /// <summary>
+  /// Enforces a pattern strategy design pattern for loading Tiled map objects
+  /// </summary>
+  public interface ITiledStrategy {
+    void Load(Map map, string layerName, int xPosition, int yPosition);
+  }
+}

--- a/src/Loaders/MapLoader.cs
+++ b/src/Loaders/MapLoader.cs
@@ -3,6 +3,7 @@ using Kazaam.Universe;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.Tiled;
 using MonoGame.Extended.Tiled.Renderers;
+using System.Collections.Generic;
 
 namespace Kazaam.Assets
 {
@@ -13,7 +14,6 @@ namespace Kazaam.Assets
     public class MapLoader : IContentLoader {
     public Map map;
     public TiledMap tiledMap;
-    
     private XNAGame game;
 
     public void SetGame(XNAGame game) {
@@ -46,19 +46,7 @@ namespace Kazaam.Assets
             if (tileTry.HasValue) {
               TiledMapTile tile = (TiledMapTile) tileTry;
               if (tile.GlobalIdentifier > 0) {
-                // Create platforms
-                switch (tileLayer.Name) {
-                  // TODO: Get rid of these hardcoded strings
-                  case "Platform":
-                    var body = new Body();
-                    body.Dimensions = new Vector2(map.tileWidth, map.tileHeight);
-                    body.Position = new Vector2(map.tileWidth * x, map.tileHeight * y);
-                    body.Bounds = map.HumperWorld.Create(body.Position.X, body.Position.Y, body.Dimensions.X, body.Dimensions.Y);
-                    body.Bounds.AddTags(Enums.Tags.Platforms);
-                    var entity = game.scene.SceneWorld.CreateEntity();
-                    entity.Attach(body);
-                    break;
-                }
+                game.scene.Strategy.Load(map, tileLayer.Name, x, y);
               }
             }
           }

--- a/src/Map.cs
+++ b/src/Map.cs
@@ -1,5 +1,4 @@
 ﻿using HumperWorld = Humper.World;
-using Kazaam.Objects;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.Tiled;

--- a/src/Scene.cs
+++ b/src/Scene.cs
@@ -1,3 +1,4 @@
+using Kazaam.Assets;
 using HumperWorld = Humper.World;
 using Kazaam.Objects;
 using Kazaam.Universe;
@@ -25,6 +26,17 @@ namespace Kazaam {
 
     public Scene(XNAGame game) {
       this.Game = game;
+    }
+
+    private ITiledStrategy _strategy;
+
+    public ITiledStrategy Strategy {
+      get {
+        return _strategy;
+      }
+      set {
+        _strategy = value;
+      }
     }
 
     /// <summary>


### PR DESCRIPTION
This removes the hardcoded "Platform" logic that's currently in MapLoader. Defining how the MapLoader loads certain layers now falls to the user. Here's an example of an implementation of ITiledStrategy

`using Kazaam;
using Kazaam.Assets;
using Kazaam.Objects;
using Kazaam.Universe;

using Microsoft.Xna.Framework;
using System;

namespace ltcolonel.src {
  public class TiledStrategy : ITiledStrategy {
    public XNAGame game;
    public void Load(Map map, string layerName, int xPosition, int yPosition) {
      switch (layerName) {
        case "Platform":
          var body = new Body();
          body.Dimensions = new Vector2(map.tileWidth, map.tileHeight);
          body.Position = new Vector2(map.tileWidth * xPosition, map.tileHeight * yPosition);
          body.Bounds = map.HumperWorld.Create(body.Position.X, body.Position.Y, body.Dimensions.X, body.Dimensions.Y);
          body.Bounds.AddTags(Kazaam.Enums.Tags.Platforms);
          var entity = game.scene.SceneWorld.CreateEntity();
          entity.Attach(body);
          break;
      }
    }
  }
}
`