### PR TITLE
Animation component and resolution independence added

### DIFF
--- a/src/Camera.cs
+++ b/src/Camera.cs
@@ -46,20 +46,22 @@ namespace Kazaam.View {
 
         public Matrix View {
             get {
-                return Matrix.CreateTranslation(
+                return
+                        Matrix.CreateTranslation(
                            - _internalCamera.Position.X,
                            - _internalCamera.Position.Y,
                            0) *
                        Matrix.CreateScale(
                            new Vector3(Zoom, Zoom, 1)) *
                        Matrix.CreateTranslation(
-                           new Vector3(_viewportWidth * 0.5f, _viewportHeight * 0.5f, 0));
+                           new Vector3(game.GameWindow.XResolution * 0.5f, game.GameWindow.YResolution * 0.5f, 0)) *
+                       Matrix.CreateScale(new Vector3(game.GameWindow.ResolutionScale.X, game.GameWindow.ResolutionScale.Y, 1.0f));
 
             }
         }
 
         public Vector2 CameraClamp(Vector2 position) {
-            var cameraMax = new Vector2(game.scene.Map.width - (_viewportWidth / Zoom / 2), game.scene.Map.height - (_viewportHeight / Zoom / 2));
+            var cameraMax = new Vector2(game.scene.Map.width * game.GameWindow.ResolutionScale.X - (_viewportWidth / Zoom / 2), game.scene.Map.height * game.GameWindow.ResolutionScale.Y - (_viewportHeight / Zoom / 2));
             return Vector2.Clamp(position,
                                  new Vector2(_viewportWidth / Zoom / 2, _viewportHeight / Zoom / 2),
                                  cameraMax);
@@ -68,6 +70,12 @@ namespace Kazaam.View {
         public Viewport Viewport {
             get {
                 return game.Graphics.Viewport;
+            }
+        }
+
+        public Vector2 Position {
+            get {
+                return _internalCamera.Position;
             }
         }
 

--- a/src/CameraManager.cs
+++ b/src/CameraManager.cs
@@ -45,5 +45,11 @@ namespace Kazaam.View {
                 currentCamera.Zoom = value;
             }
         }
+
+        public Vector2 Position {
+            get {
+                return currentCamera.Position;
+            }
+        }
     }
 }

--- a/src/Components/AnimationComponent.cs
+++ b/src/Components/AnimationComponent.cs
@@ -1,0 +1,29 @@
+﻿using Kazaam.Animate;
+using System.Collections.Generic;
+namespace Kazaam.Components {
+    public class AnimationComponent {
+
+        private Animation _currentAnimation;
+
+        /// <summary>
+        /// A dictionary of animations where the key is the animation name and the value is the set of animation frames
+        /// </summary>
+        public Dictionary<string, Animation>  Animations { get; set; }
+
+        /// <summary>
+        /// Gets and sets the current active frame in the animation
+        /// </summary>
+        public Animation CurrentAnimation { get {
+            return _currentAnimation;
+        }
+        set {
+            if (value != null) {
+                _currentAnimation = value;
+            }
+        }}
+
+        public AnimationComponent() {
+            Animations = new Dictionary<string, Animation>();
+        }
+    }
+}

--- a/src/Systems/RenderSystem.cs
+++ b/src/Systems/RenderSystem.cs
@@ -47,11 +47,7 @@ namespace Kazaam.View {
                 // Draw background. If not a background, draw the object normally.
                 if (_backgroundMapper.Has(entity)) {
                     var background = _backgroundMapper.Get(entity);
-                    _game.GameWindow.spriteBatch.Draw(background.Texture.Texture, new Vector2(_game.scene.CameraManager.Viewport.X, _game.scene.CameraManager.Viewport.Y), background.Rectangle(_game.scene.CameraManager.Viewport), Color.White, 0, Vector2.Zero, background.Zoom, SpriteEffects.None, background.LayerDepth);
-                    /*
-                    _game.GameWindow.spriteBatch.Draw(background.Texture.Texture, background.RectangleLeft(), Color.White);
-                    _game.GameWindow.spriteBatch.Draw(background.Texture.Texture, background.RectangleRight(), Color.White);
-                    */
+                    _game.GameWindow.spriteBatch.Draw(background.Texture.Texture, new Vector2(_game.scene.CameraManager.Position.X - _game.scene.CameraManager.Viewport.Width / 2, _game.scene.CameraManager.Position.Y - _game.scene.CameraManager.Viewport.Height / 4), background.Rectangle(_game.scene.CameraManager.Viewport), Color.White, 0, Vector2.Zero, background.Zoom, SpriteEffects.None, background.LayerDepth);
                 } else {
                     DrawObject(body, sourceRectangle, renderComponent);
                 }

--- a/src/XNAWindow.cs
+++ b/src/XNAWindow.cs
@@ -24,6 +24,15 @@ namespace Kazaam.Display
         public int XResolution {get; private set;}
         public int YResolution {get; private set;}
 
+        public int VirtualWidth {get; private set;}
+        public int VirtualHeight {get; private set;}
+
+        public Vector2 ResolutionScale {
+            get {
+                return new Vector2((float)graphics.GraphicsDevice.Viewport.Width / (float)VirtualWidth, (float)graphics.GraphicsDevice.Viewport.Width / (float)VirtualWidth);
+            }
+        }
+
         public XNAWindow(Game game) {
           this.game = game;
           createGraphics(false);
@@ -44,6 +53,14 @@ namespace Kazaam.Display
           Window().PreferredBackBufferWidth = XResolution;
           Window().PreferredBackBufferHeight = YResolution;
           Window().ApplyChanges();
+        }
+
+        /// <summary>
+        /// Changes the virtual resolution of the game window.
+        /// </summary>
+        public void VirtualResolution(int x, int y) {
+          VirtualWidth = x;
+          VirtualHeight = y;
         }
 
         /// <summary>


### PR DESCRIPTION
Resolution independence means the rendered items on the screen will scale to a "virtual resolution". Essentially that means you can have a window drawn at 1366x768 or at 1920x1080 and the smaller window will keep the same ratio as the larger one, drawing the same items on the screen.

A previous commit also forgot to include the AnimationComponent file, so that is also included.